### PR TITLE
riley-audit-item3.1.3

### DIFF
--- a/src/RequestsManager.sol
+++ b/src/RequestsManager.sol
@@ -69,6 +69,8 @@ contract RequestsManager is IRequestsManager, AccessControlDefaultAdminRules, Pa
     treasuryAddress = _assertNonZero(_treasuryAddress);
     providersWhitelist = IAddressesWhitelist(_assertNonZero(_providersWhitelistAddress));
 
+    if (_providersWhitelistAddress.code.length == 0) revert InvalidProvidersWhitelist(_providersWhitelistAddress);
+
     for (uint256 i = 0; i < _allowedTokenAddresses.length; i++) {
       address allowedTokenAddress = _allowedTokenAddresses[i];
       _assertNonZero(allowedTokenAddress);


### PR DESCRIPTION
3.1.3 RequestsManager does not check providersWhitelistAddress.code.length

Description: In the RequestsManager, the setProvidersWhitelist() function enforces that _providersWhitelistAddress.code.length == 0. However, the constructor() does not do this check.

Recommendation: Consider adding a check in the constructor() that enforces _providersWhitelistAddress.code.length == 0. This would mainly be for consistency