### PR TITLE
riley-audit-item3.1.4

### DIFF
--- a/src/interfaces/IRequestsManager.sol
+++ b/src/interfaces/IRequestsManager.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.28;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IRequestsManager {
-  error IdempotencyKeyAlreadyExist(bytes32 idempotencyKey);
   error InvalidAmount(uint256 amount);
   error ZeroAddress();
 


### PR DESCRIPTION
3.1.4 IRequestsManager defines redundant IdempotencyKeyAlreadyExist error

Description: The IRequestsManager interface defines the IdempotencyKeyAlreadyExist error but it does not use
it. This was likely copied from the ISimpleToken interface where it is used.

Recommendation: Consider removing the IdempotencyKeyAlreadyExist error from IRequestsManager.