### PR TITLE
fix: record idempotency key before body in SimpleToken modifiers (aud…

### DIFF
--- a/snapshots/SimpleTokenTest.json
+++ b/snapshots/SimpleTokenTest.json
@@ -1,15 +1,15 @@
 {
   "SimpleToken_burn_all": "3837",
-  "SimpleToken_burn_idempotent_first": "26250",
-  "SimpleToken_burn_idempotent_third": "26250",
+  "SimpleToken_burn_idempotent_first": "26252",
+  "SimpleToken_burn_idempotent_third": "26252",
   "SimpleToken_burn_nonIdempotent": "3837",
   "SimpleToken_burn_partial": "3837",
   "SimpleToken_initialize": "190281",
   "SimpleToken_mint_first": "54079",
-  "SimpleToken_mint_idempotent_first": "76507",
-  "SimpleToken_mint_idempotent_newAccount": "48107",
-  "SimpleToken_mint_idempotent_third": "48107",
+  "SimpleToken_mint_idempotent_first": "76509",
+  "SimpleToken_mint_idempotent_newAccount": "48109",
+  "SimpleToken_mint_idempotent_third": "48109",
   "SimpleToken_mint_nonIdempotent": "54079",
   "SimpleToken_mint_toExisting": "3779",
-  "SimpleToken_permit": "51916"
+  "SimpleToken_permit": "51915"
 }

--- a/src/SimpleToken.sol
+++ b/src/SimpleToken.sol
@@ -21,16 +21,18 @@ contract SimpleToken is ISimpleToken, Initializable, ERC20PermitUpgradeable, Acc
         if (mintIds[_idempotencyKey]) {
             revert IdempotencyKeyAlreadyExist(_idempotencyKey);
         }
-        _;
+        // CEI: record the key as consumed before running the body, so a re-entrant call
+        // (e.g. if a future _update override adds a hook) observes it as used and reverts.
         mintIds[_idempotencyKey] = true;
+        _;
     }
 
     modifier idempotentBurn(bytes32 _idempotencyKey) {
         if (burnIds[_idempotencyKey]) {
             revert IdempotencyKeyAlreadyExist(_idempotencyKey);
         }
-        _;
         burnIds[_idempotencyKey] = true;
+        _;
     }
 
     /// @custom:oz-upgrades-unsafe-allow constructor


### PR DESCRIPTION
…it #11)

idempotentMint/idempotentBurn ran the body (_mint/_burn) before recording the key, inverting checks-effects-interactions. Harmless today (OZ Upgradeable v5 _update makes no external call/hook and SimpleToken does not override it), but writing the key before the body removes the latent double-spend hazard unconditionally — cheap insurance if _update is ever overridden with a hook. Behavior-identical (idempotent paths +2 gas); SimpleToken 24/24 and V2 89/89 tests pass; gas snapshot refreshed.

Note: existing SimpleToken instances are deployed-immutable (no upgrade path), so this hardens future deployments only.