### PR TITLE
chore(deps): bump brace-expansion to 2.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,9 +148,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
Lockfile-only bump of `brace-expansion` 2.0.3 → 2.1.4, closing the three high-severity Dependabot alerts on `master`.

| Alert | Severity | Advisory | Fixed in |
|---|---|---|---|
| #4 | high | unbounded intermediate arrays (bypasses the CVE-2026-14257 mitigation) | 2.1.4 |
| #3 | high | exponential-time expansion of consecutive non-expanding `{}` groups | 2.1.2 |
| #2 | high | unbounded expansion length causing an OOM crash | 2.1.3 |

`brace-expansion` is transitive: `@openzeppelin/upgrades-core` → `minimatch@9.0.9` → `brace-expansion`. minimatch's `^2.0.1` range already admits 2.1.4, so `npm update` resolves it with no manifest change and no `overrides` entry.

## Scope

The only direct dependency in this repo is `@openzeppelin/upgrades-core`, used by openzeppelin-foundry-upgrades to run the upgrade-safety validator for `Deployment.s.sol` / `Deployment.t.sol`. It is local dev tooling — `.github/workflows/test.yml` has no node or npm step, and nothing from this tree reaches deployed bytecode.

## Alert #1 (elliptic, low) is not addressed here

There is no patched version. The advisory (GHSA-848j-6mx2-7j84) covers `elliptic *`, 6.6.1 is the latest published release, and `upgrades-core@1.46.0` still resolves the same `ethereumjs-util` → `ethereum-cryptography` → `secp256k1` → `elliptic` chain. Being dismissed as tolerable risk separately; Dependabot will reopen it if a patch ships.

## Verification

- `forge test --no-match-contract 'DeploymentTest|DeployAvETHPlusV2Test'` → 223/223 pass (the exact CI invocation)
- Fork suites under `FOUNDRY_PROFILE=artifact-deploy` → 8/8 pass, including `DeploymentTest`, which is what actually drives upgrades-core through ffi
- `forge fmt --check` clean
- `npm audit` → 0 high, only the unfixable elliptic chain remains
